### PR TITLE
Add scikit-build-core to dependencies and update torch-common

### DIFF
--- a/deactivate-torch-common.sh
+++ b/deactivate-torch-common.sh
@@ -2,7 +2,6 @@ unset NCORES
 unset MAX_JOBS
 unset CMAKE_BUILD_TYPE
 unset USE_CUDA
-unset TORCH_CUDA_ARCH_LIST
 unset USE_PRECOMPILED_HEADERS
 unset USE_PER_OPERATOR_HEADERS
 unset CCACHE_COMPRESS
@@ -13,9 +12,7 @@ unset USE_FBGEMM                               # GEMMs
 unset BUILD_TEST                               # C++ tests
 unset BUILD_CAFFE2                             # caffe2
 unset BUILD_CAFFE2_OPS                         # caffe2
-unset USE_DISTRIBUTED                          # distributed
-unset USE_NCCL                                 # distributed
-unset USE_GLOO                                 # distributed
+unset USE_SYSTEM_NCCL                          # distributed
 unset USE_QNNPACK                              # quantized
 unset USE_XNNPACK                              # quantized
 unset USE_FLASH_ATTENTION

--- a/pytorch-dev-freethreading.yaml
+++ b/pytorch-dev-freethreading.yaml
@@ -21,7 +21,7 @@ dependencies:
   - lldb
 
   # CUDA requirements, even if using system CUDA
-  - libmagma-devel
+  - libmagma-devel=2.9.*
   - cuda-driver-dev
   - cuda-version=13.0
   - cudnn
@@ -46,7 +46,7 @@ dependencies:
   - ninja
   - packaging
   - pyyaml
-  - scikit-build
+  - scikit-build-core
   - setuptools
   - sysroot_linux-64>=2.17
   - types-dataclasses

--- a/pytorch-dev-macos.yaml
+++ b/pytorch-dev-macos.yaml
@@ -16,7 +16,7 @@ dependencies:
   - ninja
   - packaging
   - pyyaml
-  - scikit-build
+  - scikit-build-core
   - setuptools
   - types-dataclasses
   - typing

--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -45,7 +45,7 @@ dependencies:
   - ninja
   - packaging
   - pyyaml
-  - scikit-build
+  - scikit-build-core
   - setuptools
   - sysroot_linux-64>=2.17
   - types-dataclasses

--- a/torch-common.sh
+++ b/torch-common.sh
@@ -14,18 +14,10 @@ export CMAKE_BUILD_TYPE=Release
 # but makes the symbol loading phase in gdb and the linking phase in compilation much slower.
 
 # CUDA
-if [[ "$(uname)" == "Darwin" ]]; then
+if ! command -v nvidia-smi >/dev/null 2>&1; then
   export USE_CUDA=0
 else
   export USE_CUDA=1
-fi
-
-if [[ -n "$TORCH_CUDA_ARCH_LIST" ]]; then
-    :
-elif [[ $(hostname) = qgpu* ]]; then
-    export TORCH_CUDA_ARCH_LIST="7.5"  # qgpu server
-else
-    export TORCH_CUDA_ARCH_LIST="8.0"  # A100 architecture
 fi
 
 # Faster recompilation


### PR DESCRIPTION
1. Add `scikit-build-core` in preparation for the new torch build pipeline.
2. Remove explicit CUDA arch setting, since the Torch CMake configuration queries it already.