### PR TITLE
Remove compilers and linkers from MacOS conda env

### DIFF
--- a/pytorch-dev-macos.yaml
+++ b/pytorch-dev-macos.yaml
@@ -6,13 +6,6 @@ dependencies:
   - python=3.10
   - pip
   - cpython
-  - compilers
-  - clang<19
-  - clangxx<19
-  - lldb
-
-  # Speedup linking
-  - mold
 
   # PyTorch dependencies
   - ccache


### PR DESCRIPTION
Compiling and linking PyTorch on MacOS needs to be done with the system compilers. Found after creating a new environment on our Mac dev host.