### PR TITLE
Explicitly use Accelerate BLAS on MacOS

### DIFF
--- a/pytorch-dev-macos.yaml
+++ b/pytorch-dev-macos.yaml
@@ -15,6 +15,11 @@ dependencies:
   # Speedup linking
   - lld
 
+  # Explicitly override BLAS to use MacOS's Accelerate framework.  Without this, Conda
+  # defaults to installing OpenBLAS, which can (in some cases) break detection of
+  # features in Accelerate, which PyTorch preferentially builds against.
+  - libblas=*=*_newaccelerate
+
   # PyTorch dependencies
   - ccache
   - cmake


### PR DESCRIPTION
Unbreaks a weird situation I've encountered while building PyTorch on MacOS in a clean Conda env.  Sometimes, somehow, the OpenBLAS library is used for feature detection in CMake (enabling `sbgemm_`), but the Accelerate library gets linked against (which does not have the OpenBLAS-specific `sbgemm_`).  This obviously breaks the built library.  If we force use of Accelerate everywhere, the problem goes away.