### PR TITLE
Use BLIS over MKL

### DIFF
--- a/pytorch-dev-freethreading.yaml
+++ b/pytorch-dev-freethreading.yaml
@@ -16,8 +16,8 @@ dependencies:
   - gdb
   # Certain features (like cpp_wrapper for inductor) can be tested in clang as
   # well.  nvcc currently supports up to clang 21.
-  - clang<21
-  - clangxx<21
+  - clang<22
+  - clangxx<22
   - lldb
 
   # Speedup linking

--- a/pytorch-dev-freethreading.yaml
+++ b/pytorch-dev-freethreading.yaml
@@ -23,6 +23,10 @@ dependencies:
   # Speedup linking
   - mold
 
+  # Explicitly override BLAS to use BLIS, which is significantly faster on AMD platforms
+  # (which represent all of our dev servers).
+  - libblas=*=*_blis
+
   # CUDA requirements, even if using system CUDA
   - libmagma-devel
   - cuda-driver-dev
@@ -43,8 +47,6 @@ dependencies:
   - ccache
   - cmake
   - fsspec
-  - mkl
-  - mkl-include
   - ninja
   - packaging
   - pyyaml

--- a/pytorch-dev.yaml
+++ b/pytorch-dev.yaml
@@ -22,6 +22,10 @@ dependencies:
   # Speedup linking
   - mold
 
+  # Explicitly override BLAS to use BLIS, which is significantly faster on AMD platforms
+  # (which represent all of our dev servers).
+  - libblas=*=*_blis
+
   # CUDA requirements, even if using system CUDA
   - libmagma-devel
   - cuda-driver-dev
@@ -42,8 +46,6 @@ dependencies:
   - ccache
   - cmake
   - fsspec
-  - mkl
-  - mkl-include
   - ninja
   - packaging
   - pyyaml

--- a/torch-build.sh
+++ b/torch-build.sh
@@ -16,7 +16,7 @@ done
 
 pip uninstall -y torchbenchmark
 pushd torchbenchmark
-python install.py
+python install.py --continue_on_fail
 popd
 
 # leave build directory

--- a/torch-env.sh
+++ b/torch-env.sh
@@ -15,5 +15,13 @@ fi
 
 eval "$(conda shell.bash hook)"
 conda activate ${PYTORCH_CONDA_ENV:=pytorch-dev${PYTORCH_BUILD_SUFFIX}}
+
+# Pin the BLAS type, so that future package installs don't inadvertently switch it.
+if [[ $OSTYPE =~ darwin ]]; then
+  echo "libblas=*=*_newaccelerate" >> $CONDA_PREFIX/conda-meta/pinned
+else
+  echo "libblas=*=*_blis" >> $CONDA_PREFIX/conda-meta/pinned
+fi
+
 echo "source $SCRIPT_DIR/torch-common.sh" > $CONDA_PREFIX/etc/conda/activate.d/activate-torch.sh
 echo "source $SCRIPT_DIR/deactivate-torch-common.sh" > $CONDA_PREFIX/etc/conda/deactivate.d/deactivate-torch.sh


### PR DESCRIPTION
Switches us over from MKL to BLIS, which is substantively faster on AMD CPUs (since Intel deliberately nerfs performance on AMD).